### PR TITLE
Add Geodesic Levenberg-Marquardt Algorithm (arXiv:1201.5885)

### DIFF
--- a/test/gaussnewton.jl
+++ b/test/gaussnewton.jl
@@ -46,7 +46,7 @@ end
     # tesing out intitialization with very large lambda, min_decrease, and min_iter
     res = copy(y)
     stn = LevenbergMarquartSettings(max_iter = 16, min_decrease = 1e-10, min_resnorm = 1e-10, min_res = 0)
-    optimize!(LM, ab, res, stn, 1e-6, Val(false), false)
+    optimize!(LM, ab, res, Val(false), stn, 1e-6, Val(true))
     @test isapprox(ab, ab0, atol = tol)
 end
 
@@ -60,7 +60,7 @@ end
     # tesing out intitialization with very large lambda, min_decrease, and min_iter
     res = copy(y)
     stn = LevenbergMarquartSettings(max_iter = 16, min_decrease = 1e-10, min_resnorm = 1e-10, min_res = 0)
-    optimize!(LM, ab, res, stn, 1e-6, Val(false), true)
+    optimize!(LM, ab, res, Val(true), stn, 1e-6, 0.01, 0.75, Val(true))
     @test isapprox(ab, ab0, atol = tol)
 end
 

--- a/test/gaussnewton.jl
+++ b/test/gaussnewton.jl
@@ -46,7 +46,21 @@ end
     # tesing out intitialization with very large lambda, min_decrease, and min_iter
     res = copy(y)
     stn = LevenbergMarquartSettings(max_iter = 16, min_decrease = 1e-10, min_resnorm = 1e-10, min_res = 0)
-    optimize!(LM, ab, res, stn) #, 1e-6, Val(true))
+    optimize!(LM, ab, res, stn, 1e-6, Val(false), false)
+    @test isapprox(ab, ab0, atol = tol)
+end
+
+@testset "Geodesic LevenbergMarquart" begin
+    n = 64
+    ab0, x, y, g, r = test_problem(n)
+    LM = LevenbergMarquart(r, ab0, y)
+    σ = .1
+    ab = ab0 + σ*randn(2)
+    tol = 1e-8
+    # tesing out intitialization with very large lambda, min_decrease, and min_iter
+    res = copy(y)
+    stn = LevenbergMarquartSettings(max_iter = 16, min_decrease = 1e-10, min_resnorm = 1e-10, min_res = 0)
+    optimize!(LM, ab, res, stn, 1e-6, Val(false), true)
     @test isapprox(ab, ab0, atol = tol)
 end
 

--- a/test/gaussnewton.jl
+++ b/test/gaussnewton.jl
@@ -46,7 +46,7 @@ end
     # tesing out intitialization with very large lambda, min_decrease, and min_iter
     res = copy(y)
     stn = LevenbergMarquartSettings(max_iter = 16, min_decrease = 1e-10, min_resnorm = 1e-10, min_res = 0)
-    optimize!(LM, ab, res, Val(false), stn, 1e-6, Val(true))
+    optimize!(LM, ab, res, Val(false), stn, 1e-6, Val(false))
     @test isapprox(ab, ab0, atol = tol)
 end
 
@@ -60,7 +60,7 @@ end
     # tesing out intitialization with very large lambda, min_decrease, and min_iter
     res = copy(y)
     stn = LevenbergMarquartSettings(max_iter = 16, min_decrease = 1e-10, min_resnorm = 1e-10, min_res = 0)
-    optimize!(LM, ab, res, Val(true), stn, 1e-6, 0.01, 0.75, Val(true))
+    optimize!(LM, ab, res, Val(true), stn, 1e-6, 0.01, 0.75, Val(false))
     @test isapprox(ab, ab0, atol = tol)
 end
 


### PR DESCRIPTION
This PR implements a geodesic variant of the Levenberg-Marquardt (LM) algorithm, as described in [arXiv:1201.5885 (2012)](https://arxiv.org/abs/1201.5885), which is expected to improve convergence behavior, especially in regions of parameter space with strong curvature.

The geodesic behavior is controlled via a singleton type flag in the `optimize`:
```julia
geodesic::Val{true}  # enables geodesic LM
geodesic::Val{false} # defaults to standard LM
```
This enables dispatch-based selection of the appropriate `optimize!` implementation, preserving efficiency and flexibility.